### PR TITLE
Delete copyright profile completely.

### DIFF
--- a/.idea/copyright/ArchitectureReloaded.xml
+++ b/.idea/copyright/ArchitectureReloaded.xml
@@ -1,6 +1,0 @@
-<component name="CopyrightManager">
-    <copyright>
-        <option name="notice" value="Copyright &amp;#36;today.year Machine Learning Methods in Software Engineering Group of JetBrains Research&#10; &#10;Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);&#10;you may not use this file except in compliance with the License.&#10;You may obtain a copy of the License at&#10; &#10;http://www.apache.org/licenses/LICENSE-2.0&#10; &#10;Unless required by applicable law or agreed to in writing, software&#10;distributed under the License is distributed on an &quot;AS IS&quot; BASIS,&#10;WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#10;See the License for the specific language governing permissions and&#10;limitations under the License." />
-        <option name="myName" value="ArchitectureReloaded" />
-    </copyright>
-</component>


### PR DESCRIPTION
IDEA still automatically chooses existing profile and generates new files with license header.
This PR removes copyright profile completely.