### PR TITLE
Migration to unique strings which describe psi elements

### DIFF
--- a/MetricsReloaded/src/main/java/com/sixrr/metrics/metricModel/MetricsRunImpl.java
+++ b/MetricsReloaded/src/main/java/com/sixrr/metrics/metricModel/MetricsRunImpl.java
@@ -121,7 +121,7 @@ public class MetricsRunImpl implements MetricsRun {
     @Override
     public void postMethodMetric(@NotNull Metric metric, @NotNull PsiMethod method, double value) {
         final MetricsResult results = getResultsForCategory(MetricCategory.Method);
-        final String signature = MethodUtils.calculateSignature(method);
+        final String signature = MethodUtils.calculateUniqueSignature(method);
         results.postValue(metric, signature, value);
         results.setElementForMeasuredObject(signature, method);
     }
@@ -170,7 +170,7 @@ public class MetricsRunImpl implements MetricsRun {
     public void postMethodMetric(@NotNull Metric metric, @NotNull PsiMethod method,
                                  double numerator, double denominator) {
         final MetricsResult results = getResultsForCategory(MetricCategory.Method);
-        final String signature = MethodUtils.calculateSignature(method);
+        final String signature = MethodUtils.calculateUniqueSignature(method);
         results.postValue(metric, signature, numerator, denominator);
         results.setElementForMeasuredObject(signature, method);
     }

--- a/MetricsReloaded/stockmetrics/src/main/java/com/sixrr/stockmetrics/halstead/HalsteadVisitor.java
+++ b/MetricsReloaded/stockmetrics/src/main/java/com/sixrr/stockmetrics/halstead/HalsteadVisitor.java
@@ -165,7 +165,7 @@ public class HalsteadVisitor extends JavaRecursiveElementVisitor {
         super.visitMethodCallExpression(callExpression);
         final PsiMethod method = callExpression.resolveMethod();
         if (method != null) {
-            final String signature = MethodUtils.calculateSignature(method);
+            final String signature = MethodUtils.calculateUniqueSignature(method);
             registerOperator(signature);
         }
     }

--- a/MetricsReloaded/utils/src/main/java/com/sixrr/metrics/utils/MethodUtils.java
+++ b/MetricsReloaded/utils/src/main/java/com/sixrr/metrics/utils/MethodUtils.java
@@ -101,7 +101,7 @@ public final class MethodUtils {
         return method.getParameterList().getParametersCount();
     }
 
-    public static String calculateSignature(PsiMethod method) {
+    private static String calculateSignature(PsiMethod method, boolean isCanonical) {
         final PsiClass containingClass = method.getContainingClass();
         final String className;
         if (containingClass != null) {
@@ -122,11 +122,20 @@ public final class MethodUtils {
                 out.append(',');
             }
             final PsiType parameterType = parameters[i].getType();
-            final String parameterTypeText = parameterType.getPresentableText();
+            final String parameterTypeText = isCanonical ?
+                    parameterType.getCanonicalText() : parameterType.getPresentableText();
             out.append(parameterTypeText);
         }
         out.append(')');
         return out.toString();
+    }
+
+    public static String calculateUniqueSignature(PsiMethod method) {
+        return calculateSignature(method, true);
+    }
+
+    public static String calculateHumanReadableSignature(PsiMethod method) {
+        return calculateSignature(method, false);
     }
 
     public static boolean isGetter(final PsiMethod method) {

--- a/MetricsReloaded/utils/src/main/java/org/jetbrains/research/groups/ml_methods/utils/PSIUtil.java
+++ b/MetricsReloaded/utils/src/main/java/org/jetbrains/research/groups/ml_methods/utils/PSIUtil.java
@@ -12,7 +12,8 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
 
-import static com.sixrr.metrics.utils.MethodUtils.calculateSignature;
+import static com.sixrr.metrics.utils.MethodUtils.calculateHumanReadableSignature;
+import static com.sixrr.metrics.utils.MethodUtils.calculateUniqueSignature;
 
 public final class PSIUtil {
     private PSIUtil() {
@@ -93,16 +94,25 @@ public final class PSIUtil {
     }
 
     public static String getHumanReadableName(@Nullable PsiElement element) {
+        return getPsiElementName(element, false);
+    }
+
+    public static String getUniqueName(@Nullable PsiElement element) {
+        return getPsiElementName(element, true);
+    }
+
+    private static String getPsiElementName(@Nullable PsiElement element, boolean isUnique) {
         if (element instanceof PsiMethod) {
-            return calculateSignature((PsiMethod) element);
+            return isUnique ?
+                    calculateUniqueSignature((PsiMethod) element) : calculateHumanReadableSignature((PsiMethod) element);
         } else if (element instanceof PsiClass) {
             if (element instanceof PsiAnonymousClass) {
-                return getHumanReadableName(((PsiAnonymousClass) element).getBaseClassReference().resolve());
+                return getPsiElementName(((PsiAnonymousClass) element).getBaseClassReference().resolve(), isUnique);
             }
             return ((PsiClass) element).getQualifiedName();
         } else if (element instanceof PsiField) {
             final PsiMember field = (PsiMember) element;
-            return getHumanReadableName(field.getContainingClass()) + "." + field.getName();
+            return getPsiElementName(field.getContainingClass(), isUnique) + "." + field.getName();
         }
         return "???";
     }

--- a/core/src/main/java/org/jetbrains/research/groups/ml_methods/algorithm/entity/EntitySearcher.java
+++ b/core/src/main/java/org/jetbrains/research/groups/ml_methods/algorithm/entity/EntitySearcher.java
@@ -19,7 +19,8 @@ import org.jetbrains.research.groups.ml_methods.utils.PSIUtil;
 
 import java.util.*;
 
-import static org.jetbrains.research.groups.ml_methods.utils.PSIUtil.getHumanReadableName;
+import static org.jetbrains.research.groups.ml_methods.utils.PSIUtil.getUniqueName;
+
 
 /**
  * Extracts every {@link CodeEntity} from {@link AnalysisScope} according to a {@link FinderStrategy} that is uses.
@@ -157,7 +158,7 @@ public class EntitySearcher {
         @Override
         public void visitClass(PsiClass aClass) {
             indicator.checkCanceled();
-            classForName.put(getHumanReadableName(aClass), aClass);
+            classForName.put(getUniqueName(aClass), aClass);
             if (!strategy.acceptClass(aClass)) {
                 return;
             }
@@ -237,7 +238,7 @@ public class EntitySearcher {
 
         @Contract("null -> false")
         private boolean isClassInProject(final @Nullable PsiClass aClass) {
-            return aClass != null && classForName.containsKey(getHumanReadableName(aClass));
+            return aClass != null && classForName.containsKey(getUniqueName(aClass));
         }
 
         @Override

--- a/core/src/main/java/org/jetbrains/research/groups/ml_methods/algorithm/entity/FieldEntity.java
+++ b/core/src/main/java/org/jetbrains/research/groups/ml_methods/algorithm/entity/FieldEntity.java
@@ -9,7 +9,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.Objects;
 
-import static org.jetbrains.research.groups.ml_methods.utils.PSIUtil.getHumanReadableName;
+import static org.jetbrains.research.groups.ml_methods.utils.PSIUtil.getUniqueName;
 
 public class FieldEntity extends ClassInnerEntity {
     private final @NotNull PsiField psiField;
@@ -31,7 +31,7 @@ public class FieldEntity extends ClassInnerEntity {
     @Override
     public @NotNull String getIdentifier() {
         return ApplicationManager.getApplication().runReadAction(
-            (Computable<String>) () -> getHumanReadableName(psiField.getContainingClass()) + "." + psiField.getName()
+            (Computable<String>) () -> getUniqueName(psiField.getContainingClass()) + "." + psiField.getName()
         );
     }
 

--- a/core/src/main/java/org/jetbrains/research/groups/ml_methods/algorithm/entity/MethodEntity.java
+++ b/core/src/main/java/org/jetbrains/research/groups/ml_methods/algorithm/entity/MethodEntity.java
@@ -30,7 +30,7 @@ public class MethodEntity extends ClassInnerEntity {
     @Override
     public @NotNull String getIdentifier() {
         return ApplicationManager.getApplication().runReadAction(
-            (Computable<String>) () -> MethodUtils.calculateSignature(psiMethod)
+            (Computable<String>) () -> MethodUtils.calculateUniqueSignature(psiMethod)
         );
     }
 

--- a/core/src/main/java/org/jetbrains/research/groups/ml_methods/utils/RefactoringUtil.java
+++ b/core/src/main/java/org/jetbrains/research/groups/ml_methods/utils/RefactoringUtil.java
@@ -15,7 +15,7 @@ import java.util.*;
 import java.util.Map.Entry;
 import java.util.stream.Collectors;
 
-import static org.jetbrains.research.groups.ml_methods.utils.PSIUtil.getHumanReadableName;
+import static org.jetbrains.research.groups.ml_methods.utils.PSIUtil.getUniqueName;
 
 public final class RefactoringUtil {
     private static Logger LOG = Logging.getLogger(RefactoringUtil.class);
@@ -52,9 +52,9 @@ public final class RefactoringUtil {
         return refactorings.stream()
                 .flatMap(List::stream)
                 .collect(Collectors.groupingBy(refactoring ->
-                                getHumanReadableName(refactoring.getRefactoring().getEntity()) +
+                                getUniqueName(refactoring.getRefactoring().getEntity()) +
                                         "&" +
-                                        getHumanReadableName(refactoring.getRefactoring().getTargetClass()),
+                                        getUniqueName(refactoring.getRefactoring().getTargetClass()),
                         Collectors.toList()))
                 .values().stream()
                 .filter(collection -> collection.size() == refactorings.size())

--- a/core/src/test/java/org/jetbrains/research/groups/ml_methods/algorithm/TestCasesCheckers.java
+++ b/core/src/test/java/org/jetbrains/research/groups/ml_methods/algorithm/TestCasesCheckers.java
@@ -11,6 +11,7 @@ import static com.intellij.testFramework.UsefulTestCase.assertContainsElements;
 import static com.intellij.testFramework.UsefulTestCase.assertOneOf;
 import static junit.framework.TestCase.assertTrue;
 import static org.jetbrains.research.groups.ml_methods.utils.PSIUtil.getHumanReadableName;
+import static org.jetbrains.research.groups.ml_methods.utils.PSIUtil.getUniqueName;
 import static org.junit.Assert.assertEquals;
 
 class TestCasesCheckers {
@@ -23,8 +24,8 @@ class TestCasesCheckers {
 
     private static Map<String, String> toMap(List<CalculatedRefactoring> refactorings) {
         return refactorings.stream().collect(Collectors.toMap(it ->
-                getHumanReadableName(it.getRefactoring().getEntity()),
-                it -> getHumanReadableName(it.getRefactoring().getTargetClass())));
+                getUniqueName(it.getRefactoring().getEntity()),
+                it -> getUniqueName(it.getRefactoring().getTargetClass())));
     }
 
     @NotNull

--- a/features-extraction/src/main/java/org/jetbrains/research/groups/ml_methods/extraction/refactoring/JMoveRefactoringTextRepresentation.java
+++ b/features-extraction/src/main/java/org/jetbrains/research/groups/ml_methods/extraction/refactoring/JMoveRefactoringTextRepresentation.java
@@ -19,7 +19,7 @@ public class JMoveRefactoringTextRepresentation extends RefactoringTextRepresent
 
     @Override
     public boolean isOfGivenMethod(PsiMethod method) {
-        String methodsSignature = MethodUtils.calculateSignature(method);
+        String methodsSignature = MethodUtils.calculateHumanReadableSignature(method);
         String methodsSignatureWithoutParams = methodsSignature.split("\\(")[0];
         String refactoringSignature = getMethodsSignature();
         return refactoringSignature.equals(methodsSignature) ||

--- a/features-extraction/src/main/java/org/jetbrains/research/groups/ml_methods/extraction/refactoring/RefactoringsFinder.java
+++ b/features-extraction/src/main/java/org/jetbrains/research/groups/ml_methods/extraction/refactoring/RefactoringsFinder.java
@@ -106,8 +106,8 @@ public class RefactoringsFinder extends JavaRecursiveElementVisitor {
             this.method = method;
 
             if (oldMethod != null) {
-                String oldSignature = MethodUtils.calculateSignature(oldMethod);
-                String newSignature = MethodUtils.calculateSignature(method);
+                String oldSignature = MethodUtils.calculateHumanReadableSignature(oldMethod);
+                String newSignature = MethodUtils.calculateHumanReadableSignature(method);
 
                 throw new IllegalStateException("Refactorings set is ambiguous. Candidates: " +
                         oldSignature + ", " + newSignature);

--- a/features-extraction/src/test/java/org/jetbrains/research/groups/ml_methods/extraction/info/InfoCollectorTest.java
+++ b/features-extraction/src/test/java/org/jetbrains/research/groups/ml_methods/extraction/info/InfoCollectorTest.java
@@ -107,13 +107,13 @@ public class InfoCollectorTest extends ScopeAbstractTest {
         assertSameElements(
             repository.getMethods()
                       .stream()
-                      .map(MethodUtils::calculateSignature)
+                      .map(MethodUtils::calculateUniqueSignature)
                       .collect(Collectors.toList()),
             validator.methodNames()
         );
 
         for (PsiMethod method : repository.getMethods()) {
-            String methodName = MethodUtils.calculateSignature(method);
+            String methodName = MethodUtils.calculateUniqueSignature(method);
 
             MethodInfo info = repository.getMethodInfo(method).orElseThrow(
                 () -> new IllegalStateException(
@@ -124,7 +124,7 @@ public class InfoCollectorTest extends ScopeAbstractTest {
             assertSameElements(
                 info.getSameInstanceCallers()
                     .stream()
-                    .map(MethodUtils::calculateSignature)
+                    .map(MethodUtils::calculateUniqueSignature)
                     .collect(Collectors.toList()),
                 validator.getSameObjectCallers(methodName)
             );
@@ -132,7 +132,7 @@ public class InfoCollectorTest extends ScopeAbstractTest {
             assertSameElements(
                 info.getAnotherInstanceCallers()
                     .stream()
-                    .map(MethodUtils::calculateSignature)
+                    .map(MethodUtils::calculateUniqueSignature)
                     .collect(Collectors.toList()),
                 validator.getAnotherObjectCallers(methodName)
             );
@@ -140,7 +140,7 @@ public class InfoCollectorTest extends ScopeAbstractTest {
             assertSameElements(
                 info.getSameInstanceTargets()
                     .stream()
-                    .map(MethodUtils::calculateSignature)
+                    .map(MethodUtils::calculateUniqueSignature)
                     .collect(Collectors.toList()),
                 validator.getSameObjectTargets(methodName)
             );
@@ -148,7 +148,7 @@ public class InfoCollectorTest extends ScopeAbstractTest {
             assertSameElements(
                 info.getAnotherInstanceTargets()
                     .stream()
-                    .map(MethodUtils::calculateSignature)
+                    .map(MethodUtils::calculateUniqueSignature)
                     .collect(Collectors.toList()),
                 validator.getAnotherObjectTargets(methodName)
             );
@@ -156,7 +156,7 @@ public class InfoCollectorTest extends ScopeAbstractTest {
             assertSameElements(
                 info.getAccessedFields()
                     .stream()
-                    .map(PSIUtil::getHumanReadableName)
+                    .map(PSIUtil::getUniqueName)
                     .collect(Collectors.toList()),
                 validator.getAccessedFields(methodName)
             );

--- a/src/main/java/org/jetbrains/research/groups/ml_methods/refactoring/logging/MoveMethodRefactoringFeatures.java
+++ b/src/main/java/org/jetbrains/research/groups/ml_methods/refactoring/logging/MoveMethodRefactoringFeatures.java
@@ -48,7 +48,7 @@ public class MoveMethodRefactoringFeatures extends RefactoringFeatures {
         );
 
         methodMetricsValues = extractMetricsResultsFor(
-            MethodUtils.calculateSignature(refactoring.getMethod()),
+            MethodUtils.calculateUniqueSignature(refactoring.getMethod()),
             resultsForMethods
         );
     }


### PR DESCRIPTION
Fixes #89 
Migrated to unique strings that describes psi elements. Human readable now is used only for user's output.