### PR TITLE
Fixes "Set of overloaded methods must contain original method" exception

### DIFF
--- a/MetricsReloaded/stockmetrics/src/main/java/com/sixrr/stockmetrics/methodCalculators/NumOverloadsCalculator.java
+++ b/MetricsReloaded/stockmetrics/src/main/java/com/sixrr/stockmetrics/methodCalculators/NumOverloadsCalculator.java
@@ -17,7 +17,8 @@ public class NumOverloadsCalculator extends MethodCalculator {
         public void visitMethod(PsiMethod method) {
             PsiClass containingClass = method.getContainingClass();
             if (containingClass != null) {
-                postMetric(method, MethodUtils.getNumberOfOverloads(method, containingClass, true));
+                postMetric(method,
+                        MethodUtils.getNumberOfOverloads(method, containingClass, true) - 1);
             }
             super.visitMethod(method);
         }


### PR DESCRIPTION
Changed remove() on filter() by unique signature and changed throwing exception on writing to logger in getOverloads() method.
Fixes #158 